### PR TITLE
Shift distance measurement tooltip downwards a bit

### DIFF
--- a/style.css
+++ b/style.css
@@ -285,6 +285,7 @@ body {
 
 #measure-tooltip {
     background-color: #fff;
+    transform: translate(0, 20px);
 }
 
 #target-tooltip.target-compid-0 {


### PR DESCRIPTION
Because otherwise the target tooltip & the distance measurement tooltip might run into each other and it's not pretty.
